### PR TITLE
Timer + callback to set status every 5 minutes, hopefully fixes #32

### DIFF
--- a/libteams.c
+++ b/libteams.c
@@ -48,6 +48,8 @@ teams_do_all_the_things(TeamsAccount *sa)
 		skype_web_get_offline_history(sa);
 
 		teams_set_status(sa->account, purple_account_get_active_status(sa->account));
+        sa->status_last_set_timeout = g_timeout_add_seconds(250, (GSourceFunc)teams_set_status_timeout_cb, sa);
+
 	} else {
 		//Too soon!
 		teams_subscribe(sa);

--- a/libteams.c
+++ b/libteams.c
@@ -48,6 +48,8 @@ teams_do_all_the_things(TeamsAccount *sa)
 		skype_web_get_offline_history(sa);
 
 		teams_set_status(sa->account, purple_account_get_active_status(sa->account));
+        if(sa->status_last_set_timeout)
+            g_source_remove(sa->status_last_set_timeout);
         sa->status_last_set_timeout = g_timeout_add_seconds(250, (GSourceFunc)teams_set_status_timeout_cb, sa);
 
 	} else {
@@ -400,7 +402,8 @@ teams_close(PurpleConnection *pc)
 	
 	sa = purple_connection_get_protocol_data(pc);
 	g_return_if_fail(sa != NULL);
-	
+
+    g_source_remove(sa->status_last_set_timeout);
 	g_source_remove(sa->friend_list_poll_timeout);
 	g_source_remove(sa->authcheck_timeout);
 	g_source_remove(sa->poll_timeout);

--- a/libteams.h
+++ b/libteams.h
@@ -189,7 +189,7 @@ struct _TeamsAccount {
 	GHashTable *buddy_to_chat_lookup;
 	GHashTable *chat_to_buddy_lookup;
 	gint refresh_token_timeout;
-    gint status_last_set_timeout;
+    guint status_last_set_timeout;
 	gchar *csa_access_token;
 	gchar *presence_access_token;
 	struct _TeamsConnection *poll_conn;

--- a/libteams.h
+++ b/libteams.h
@@ -189,6 +189,7 @@ struct _TeamsAccount {
 	GHashTable *buddy_to_chat_lookup;
 	GHashTable *chat_to_buddy_lookup;
 	gint refresh_token_timeout;
+    gint status_last_set_timeout;
 	gchar *csa_access_token;
 	gchar *presence_access_token;
 	struct _TeamsConnection *poll_conn;

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -2020,10 +2020,16 @@ teams_set_status(PurpleAccount *account, PurpleStatus *status)
 }
 
 
-void
+gboolean
 teams_set_status_timeout_cb(TeamsAccount* sa)
 {
+    if(sa == NULL || sa->account == NULL) {
+        purple_debug_warning("teams", "Set status cb (sa == NULL || sa->account == NULL); cancel timer.");
+        return FALSE;
+    }
+
     teams_set_status(sa->account, purple_account_get_active_status(sa->account));
+    return TRUE;
 }
 
 void

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -1999,10 +1999,6 @@ teams_set_statusid(TeamsAccount *sa, const gchar *status)
 	teams_post_or_get(sa, TEAMS_METHOD_PUT | TEAMS_METHOD_SSL, TEAMS_PRESENCE_HOST, "/v1/me/forceavailability/", post, NULL, NULL, TRUE);
 	g_free(post);
 	
-	return;
-	
-	//TODO whats this one?
-	
 	//https://presence.teams.microsoft.com/v1/me/endpoints/
 	post = g_strdup_printf("{\"id\":\"%s\",\"activity\":\"%s\",\"deviceType\":\"Desktop\"}", sa->endpoint, status);
 	teams_post_or_get(sa, TEAMS_METHOD_PUT | TEAMS_METHOD_SSL, TEAMS_PRESENCE_HOST, "/v1/me/endpoints/", post, NULL, NULL, TRUE);
@@ -2021,6 +2017,13 @@ teams_set_status(PurpleAccount *account, PurpleStatus *status)
 	
 	teams_set_statusid(sa, purple_status_get_id(status));
 	teams_set_mood_message(sa, purple_status_get_attr_string(status, "message"));
+}
+
+
+void
+teams_set_status_timeout_cb(TeamsAccount* sa)
+{
+    teams_set_status(sa->account, purple_account_get_active_status(sa->account));
 }
 
 void

--- a/teams_messages.h
+++ b/teams_messages.h
@@ -39,7 +39,7 @@ const gchar *message, PurpleMessageFlags flags
 
 void teams_set_idle(PurpleConnection *pc, int time);
 void teams_set_status(PurpleAccount *account, PurpleStatus *status);
-void teams_set_status_timeout_cb(TeamsAccount *sa);
+gboolean teams_set_status_timeout_cb(TeamsAccount *sa);
 guint teams_conv_send_typing(PurpleConversation *conv, PurpleIMTypingState state);
 guint teams_send_typing(PurpleConnection *pc, const gchar *name, PurpleIMTypingState state);
 void teams_poll(TeamsAccount *sa);

--- a/teams_messages.h
+++ b/teams_messages.h
@@ -39,6 +39,7 @@ const gchar *message, PurpleMessageFlags flags
 
 void teams_set_idle(PurpleConnection *pc, int time);
 void teams_set_status(PurpleAccount *account, PurpleStatus *status);
+void teams_set_status_timeout_cb(TeamsAccount *sa);
 guint teams_conv_send_typing(PurpleConversation *conv, PurpleIMTypingState state);
 guint teams_send_typing(PurpleConnection *pc, const gchar *name, PurpleIMTypingState state);
 void teams_poll(TeamsAccount *sa);


### PR DESCRIPTION
Add timer + callback to set status at least once every 5 minutes as described here: https://learn.microsoft.com/en-us/graph/api/presence-setpresence?view=graph-rest-1.0&tabs=http

```
A presence session can time out if the availability is Available and the timeout is 5 minutes. When it times out, the presence state fades in stages. For example, if an application sets the presence session as Available/Available, the state would change to Available/AvailableInactive in 5 minutes with the first timeout, then Away/Away in another 5 minutes with the second timeout.
```

This callback sets the current active status at least every 5 minutes to make sure it is never expiring. A future fix would be to support the MS Graph API and set the status timeout.

Please note that I have never done pidgin or glib related work before and most of my day to day work is in C++.

I've tested this with two different teams accounts in the same tenant. The desktop client shows the Pidgin account still online after 15 minutes (instead of away / offline).