### PR TITLE
Unref JSON object

### DIFF
--- a/teams_trouter.c
+++ b/teams_trouter.c
@@ -116,6 +116,7 @@ teams_trouter_send_authentication(TeamsAccount *sa)
 	gchar *message = teams_jsonobj_to_string(obj);
 	teams_trouter_send_ephemeral_message(sa, message);
 	g_free(message);
+	json_object_unref(obj);
 }
 
 static void


### PR DESCRIPTION
I think the JsonObject reference count never reaches zero (but I'm not sure because I am not at all familiar with JSON-glib).

I have been running with this change for a couple of days, and the memory usage no longer seems to increase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced resource management in the authentication process to prevent potential memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->