### PR TITLE
Prevent UI stutter from presence and profile request storms

### DIFF
--- a/glibcompat.h
+++ b/glibcompat.h
@@ -33,16 +33,6 @@ g_slist_copy_deep(GSList *list, GCopyFunc copy_func, gpointer user_data)
 
 #if !GLIB_CHECK_VERSION(2, 32, 0)
 #define g_hash_table_contains(hash_table, key) g_hash_table_lookup_extended((hash_table), (key), NULL, NULL)
-
-static inline void
-g_queue_free_full(GQueue *queue, GDestroyNotify free_func)
-{
-	while (!g_queue_is_empty(queue)) {
-		gpointer item = g_queue_pop_head(queue);
-		free_func(item);
-	}
-	g_queue_free(queue);
-}
 #endif /* 2.32.0 */
 
 #if !GLIB_CHECK_VERSION(2, 28, 0)

--- a/glibcompat.h
+++ b/glibcompat.h
@@ -3,6 +3,14 @@
 
 #include <glib.h>
 
+#ifndef G_SOURCE_REMOVE
+#define G_SOURCE_REMOVE 0
+#endif /* G_SOURCE_REMOVE */
+
+#ifndef G_SOURCE_CONTINUE
+#define G_SOURCE_CONTINUE 1
+#endif /* G_SOURCE_CONTINUE */
+
 #if !GLIB_CHECK_VERSION(2, 68, 0)
 #define g_memdup2(mem, size) g_memdup((mem), (size))
 #endif /* 2.68.0 */
@@ -25,6 +33,16 @@ g_slist_copy_deep(GSList *list, GCopyFunc copy_func, gpointer user_data)
 
 #if !GLIB_CHECK_VERSION(2, 32, 0)
 #define g_hash_table_contains(hash_table, key) g_hash_table_lookup_extended((hash_table), (key), NULL, NULL)
+
+static inline void
+g_queue_free_full(GQueue *queue, GDestroyNotify free_func)
+{
+	while (!g_queue_is_empty(queue)) {
+		gpointer item = g_queue_pop_head(queue);
+		free_func(item);
+	}
+	g_queue_free(queue);
+}
 #endif /* 2.32.0 */
 
 #if !GLIB_CHECK_VERSION(2, 28, 0)

--- a/libteams.c
+++ b/libteams.c
@@ -423,6 +423,49 @@ teams_node_menu(PurpleBlistNode *node)
 
 static gulong conversation_updated_signal = 0;
 static gulong chat_conversation_typing_signal = 0;
+static gulong im_conversation_created_signal = 0;
+
+static void
+teams_im_conversation_created(PurpleConversation *conv)
+{
+	PurpleConnection *pc;
+	TeamsAccount *sa;
+	PurpleAccount *account;
+	const gchar *buddyname;
+	const gchar *convname;
+	gint history_days;
+	gint since;
+
+	if (!PURPLE_IS_IM_CONVERSATION(conv))
+		return;
+
+	pc = purple_conversation_get_connection(conv);
+	if (!PURPLE_CONNECTION_IS_CONNECTED(pc))
+		return;
+
+	if (!purple_strequal(purple_protocol_get_id(purple_connection_get_protocol(pc)), TEAMS_PLUGIN_ID))
+		return;
+
+	account = purple_connection_get_account(pc);
+
+	if (!purple_account_get_bool(account, "fetch-history", TRUE))
+		return;
+
+	history_days = purple_account_get_int(account, "history-days", 7);
+	if (history_days <= 0)
+		return;
+
+	sa = purple_connection_get_protocol_data(pc);
+
+	buddyname = purple_conversation_get_name(conv);
+	convname = g_hash_table_lookup(sa->buddy_to_chat_lookup, buddyname);
+
+	if (convname == NULL || *convname == '\0')
+		return;
+
+	since = (gint)(time(NULL) - (time_t)history_days * 86400);
+	teams_fetch_conv_history_paginated(sa, convname, since);
+}
 
 static void
 teams_login(PurpleAccount *account)
@@ -488,6 +531,9 @@ teams_login(PurpleAccount *account)
 			// Typing signal doesn't exist in this libpurple version
 			chat_conversation_typing_signal = G_MAXULONG;
 		}
+	}
+	if (!im_conversation_created_signal) {
+		im_conversation_created_signal = purple_signal_connect(purple_conversations_get_handle(), "conversation-created", purple_connection_get_protocol(pc), PURPLE_CALLBACK(teams_im_conversation_created), NULL);
 	}
 	// Setup callbacks for the preferences.
 	// handle = purple_proxy_get_handle();
@@ -989,6 +1035,12 @@ teams_protocol_init(PurpleProtocol *prpl_info)
 	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
 	
 	opt = purple_account_option_int_new(_("Notify me before meeting begins (minutes)"), "calendar_notify_minutes", -1);
+	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
+	
+	opt = purple_account_option_bool_new(_("Fetch conversation history when opening IM window"), "fetch-history", TRUE);
+	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
+	
+	opt = purple_account_option_int_new(_("Days of history to fetch"), "history-days", 7);
 	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
 
 #undef TEAMS_PRPL_APPEND_ACCOUNT_OPTION

--- a/libteams.c
+++ b/libteams.c
@@ -483,6 +483,10 @@ teams_login(PurpleAccount *account)
 	}
 	if (!chat_conversation_typing_signal) {
 		chat_conversation_typing_signal = purple_signal_connect(purple_conversations_get_handle(), "chat-conversation-typing", purple_connection_get_protocol(pc), PURPLE_CALLBACK(teams_conv_send_typing), NULL);
+		if (!chat_conversation_typing_signal) {
+			// Typing signal doesn't exist in this libpurple version
+			chat_conversation_typing_signal = G_MAXULONG;
+		}
 	}
 	// Setup callbacks for the preferences.
 	// handle = purple_proxy_get_handle();
@@ -512,15 +516,22 @@ teams_close(PurpleConnection *pc)
 	
 	sa = purple_connection_get_protocol_data(pc);
 	g_return_if_fail(sa != NULL);
-	
-	g_source_remove(sa->calendar_poll_timeout);
-	g_source_remove(sa->authcheck_timeout);
-	g_source_remove(sa->poll_timeout);
-	g_source_remove(sa->watchdog_timeout);
-	g_source_remove(sa->refresh_token_timeout);
-	g_source_remove(sa->idle_timeout);
-	g_source_remove(sa->login_device_code_expires_timeout);
-	g_source_remove(sa->login_device_code_timeout);
+
+	// Flush pending icon downloads for this account before cancelling
+	// HTTP connections. Otherwise the queue timer may fire after sa is
+	// freed and dereference a dangling sbuddy->sa pointer.
+	teams_flush_icon_queue_for_account(sa->account);
+
+	if (sa->calendar_poll_timeout)            g_source_remove(sa->calendar_poll_timeout);
+	if (sa->authcheck_timeout)                g_source_remove(sa->authcheck_timeout);
+	if (sa->poll_timeout)                     g_source_remove(sa->poll_timeout);
+	if (sa->watchdog_timeout)                 g_source_remove(sa->watchdog_timeout);
+	if (sa->refresh_token_timeout)            g_source_remove(sa->refresh_token_timeout);
+	if (sa->idle_timeout)                     g_source_remove(sa->idle_timeout);
+	if (sa->login_device_code_expires_timeout) g_source_remove(sa->login_device_code_expires_timeout);
+	if (sa->login_device_code_timeout)        g_source_remove(sa->login_device_code_timeout);
+	if (sa->presence_drain_source)            { g_source_remove(sa->presence_drain_source); sa->presence_drain_source = 0; }
+	if (sa->subscription_flush_timer)         { g_source_remove(sa->subscription_flush_timer); sa->subscription_flush_timer = 0; }
 	// Trouter timeouts handled in teams_trouter_stop()
 
 	teams_logout(sa);

--- a/libteams.c
+++ b/libteams.c
@@ -456,6 +456,7 @@ teams_login(PurpleAccount *account)
 	sa->subscription_flush_timer = 0;
 	sa->pending_presences = g_queue_new();
 	sa->presence_drain_source = 0;
+	sa->presence_mri_index = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 	sa->keepalive_pool = purple_http_keepalive_pool_new();
 	purple_http_keepalive_pool_set_limit_per_host(sa->keepalive_pool, TEAMS_MAX_CONNECTIONS);
 	sa->conns = purple_http_connection_set_new();
@@ -589,6 +590,7 @@ teams_close(PurpleConnection *pc)
 		sa->presence_drain_source = 0;
 	}
 	g_queue_free_full(sa->pending_presences, (GDestroyNotify) json_object_unref);
+	g_hash_table_destroy(sa->presence_mri_index);
 	
 	g_free(sa->login_device_code);
 	g_free(sa->substrate_access_token);

--- a/libteams.c
+++ b/libteams.c
@@ -972,6 +972,9 @@ teams_protocol_init(PurpleProtocol *prpl_info)
 	opt = purple_account_option_bool_new(_("Collapse Teams threads into a single chat window"), "should_collapse_threads", TRUE);
 	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
 	
+	opt = purple_account_option_bool_new(_("Hide meeting chats from buddy list"), "hide_meeting_chats", FALSE);
+	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
+	
 	opt = purple_account_option_int_new(_("Notify me before meeting begins (minutes)"), "calendar_notify_minutes", -1);
 	TEAMS_PRPL_APPEND_ACCOUNT_OPTION(opt);
 

--- a/libteams.c
+++ b/libteams.c
@@ -449,6 +449,13 @@ teams_login(PurpleAccount *account)
 	sa->buddy_to_chat_lookup = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	sa->chat_to_buddy_lookup = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	sa->calendar_reminder_timeouts = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+	sa->subscribed_contacts = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+	sa->fetched_profiles = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+	sa->presence_etag_cache = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	sa->pending_subscription_contacts = g_queue_new();
+	sa->subscription_flush_timer = 0;
+	sa->pending_presences = g_queue_new();
+	sa->presence_drain_source = 0;
 	sa->keepalive_pool = purple_http_keepalive_pool_new();
 	purple_http_keepalive_pool_set_limit_per_host(sa->keepalive_pool, TEAMS_MAX_CONNECTIONS);
 	sa->conns = purple_http_connection_set_new();
@@ -558,6 +565,19 @@ teams_close(PurpleConnection *pc)
 	g_hash_table_destroy(sa->buddy_to_chat_lookup);
 	g_hash_table_destroy(sa->chat_to_buddy_lookup);
 	g_hash_table_destroy(sa->calendar_reminder_timeouts);
+	g_hash_table_destroy(sa->subscribed_contacts);
+	g_hash_table_destroy(sa->fetched_profiles);
+	g_hash_table_destroy(sa->presence_etag_cache);
+	if (sa->subscription_flush_timer != 0) {
+		g_source_remove(sa->subscription_flush_timer);
+		sa->subscription_flush_timer = 0;
+	}
+	g_queue_free_full(sa->pending_subscription_contacts, g_free);
+	if (sa->presence_drain_source != 0) {
+		g_source_remove(sa->presence_drain_source);
+		sa->presence_drain_source = 0;
+	}
+	g_queue_free_full(sa->pending_presences, (GDestroyNotify) json_object_unref);
 	
 	g_free(sa->login_device_code);
 	g_free(sa->substrate_access_token);

--- a/libteams.c
+++ b/libteams.c
@@ -630,12 +630,20 @@ teams_close(PurpleConnection *pc)
 		g_source_remove(sa->subscription_flush_timer);
 		sa->subscription_flush_timer = 0;
 	}
-	g_queue_free_full(sa->pending_subscription_contacts, g_free);
+	while (!g_queue_is_empty(sa->pending_subscription_contacts)) {
+		GSList *l = g_queue_pop_head(sa->pending_subscription_contacts);
+		g_slist_free_full(l, g_free);
+	}
+	g_queue_free(sa->pending_subscription_contacts);
 	if (sa->presence_drain_source != 0) {
 		g_source_remove(sa->presence_drain_source);
 		sa->presence_drain_source = 0;
 	}
-	g_queue_free_full(sa->pending_presences, (GDestroyNotify) json_object_unref);
+	while (!g_queue_is_empty(sa->pending_presences)) {
+		gpointer presence = g_queue_pop_head(sa->pending_presences);
+		g_free(presence);
+	}
+	g_queue_free(sa->pending_presences);
 	g_hash_table_destroy(sa->presence_mri_index);
 	
 	g_free(sa->login_device_code);

--- a/libteams.h
+++ b/libteams.h
@@ -225,6 +225,14 @@ struct _TeamsAccount {
 	GHashTable *calendar_reminder_timeouts;
 	guint calendar_poll_timeout;
 	GQueue *processed_event_messages;
+	GHashTable *subscribed_contacts;
+	GHashTable *fetched_profiles;
+	GHashTable *presence_etag_cache;
+	GQueue *pending_subscription_contacts;
+	guint subscription_flush_timer;
+	GQueue *pending_presences;
+	guint presence_drain_source;
+	GHashTable *presence_mri_index;
 	
 	struct _PurpleWebsocket *trouter_socket;
 	gchar *trouter_surl;

--- a/libteams.h
+++ b/libteams.h
@@ -232,7 +232,6 @@ struct _TeamsAccount {
 	guint subscription_flush_timer;
 	GQueue *pending_presences;
 	guint presence_drain_source;
-	GHashTable *presence_mri_index;
 	
 	struct _PurpleWebsocket *trouter_socket;
 	gchar *trouter_surl;

--- a/libteams.h
+++ b/libteams.h
@@ -232,6 +232,7 @@ struct _TeamsAccount {
 	guint subscription_flush_timer;
 	GQueue *pending_presences;
 	guint presence_drain_source;
+	GHashTable *presence_mri_index;
 	
 	struct _PurpleWebsocket *trouter_socket;
 	gchar *trouter_surl;

--- a/libteams.h
+++ b/libteams.h
@@ -171,6 +171,8 @@
 #define TEAMS_BUDDY_IS_SKYPE(a) G_UNLIKELY((a) != NULL && g_str_has_prefix((a), "8:") && !g_str_has_prefix((a), "8:orgid:"))
 #define TEAMS_BUDDY_IS_TEAMS(a) G_LIKELY((a) != NULL && g_str_has_prefix((a), "8:orgid:"))
 
+#define TEAMS_CHAT_IS_MEETING(a) G_LIKELY((a) != NULL && g_str_has_prefix((a), "19:meeting_"))
+
 #define TEAMS_OOO_STATUS_ID "OutOfOffice"
 #define TEAMS_WORK_LOCATION_STATUS_ID "WorkLocation"
 

--- a/teams_contacts.c
+++ b/teams_contacts.c
@@ -79,9 +79,8 @@ static guint active_icon_downloads = 0;
 
 static void teams_get_icon_now(PurpleBuddy *buddy);
 
-static GQueue    *icon_download_queue = NULL;
-static GHashTable *icon_queue_set     = NULL;
-static guint      icon_queue_timer_id = 0;
+static GQueue *icon_download_queue = NULL;
+static guint   icon_queue_timer_id = 0;
 
 static gboolean
 teams_process_icon_queue(gpointer data)
@@ -98,6 +97,10 @@ teams_process_icon_queue(gpointer data)
 
 	PurpleBuddy *buddy = g_queue_pop_head(icon_download_queue);
 	if (buddy) {
+		// Remove from the deduplication set now that it is being processed.
+		if (icon_queue_set != NULL) {
+			g_hash_table_remove(icon_queue_set, buddy);
+		}
 		teams_get_icon_now(buddy);
 	}
 
@@ -128,6 +131,31 @@ teams_get_icon_cb(PurpleHttpConnection *http_conn, PurpleHttpResponse *response,
 	if (!len || !*data) {
 		return;
 	}
+
+	// Reject responses that are too small to contain a valid image header,
+	// or that don't begin with a recognised image magic sequence.
+	// The Teams API returns short JSON bodies (e.g. "{}") for users with no
+	// avatar. Storing these 2-byte blobs via purple_buddy_icons_set_for_user()
+	// corrupts the icon store and ultimately the heap.
+	if (len < 8 ||
+	    (memcmp(data, "\x89PNG",     4) != 0 &&   /* PNG  */
+	     memcmp(data, "\xff\xd8\xff", 3) != 0 &&   /* JPEG */
+	     memcmp(data, "GIF8",        4) != 0 &&   /* GIF  */
+	     memcmp(data, "BM",          2) != 0 &&   /* BMP  */
+	     memcmp(data, "RIFF",        4) != 0)) {  /* WebP */
+		purple_debug_warning("teams", "Ignoring non-image response (%" G_GSIZE_FORMAT " bytes) for %s\n",
+		                     len, purple_buddy_get_name(buddy));
+		return;
+	}
+
+	// A buddy icon should never be larger than 10 MB. A garbage size probably
+	// indicates heap corruption. It is better to skip the icon since that will
+	// prevent propagation of a potentially corrupt icon into the icon store.
+	if (len > 10 * 1024 * 1024) {
+		purple_debug_warning("teams", "Ignoring suspiciously large icon response (%" G_GSIZE_FORMAT " bytes) for %s\n",
+		                     len, purple_buddy_get_name(buddy));
+		return;
+	}
 	
 	purple_buddy_icons_set_for_user(purple_buddy_get_account(buddy), purple_buddy_get_name(buddy), g_memdup2(data, len), len, url);
 	
@@ -150,12 +178,15 @@ teams_get_icon_now(PurpleBuddy *buddy)
 
 	sa = sbuddy->sa;
 
+	const gchar *buddy_name = purple_buddy_get_name(buddy);
+	if (!buddy_name || !*buddy_name)
+		return;
+
 	if (sbuddy->avatar_url && sbuddy->avatar_url[0]) {
 		url = g_strdup(sbuddy->avatar_url);
 	} else {
 		const gchar *self = teams_strip_user_prefix(sa->username);
 		const gchar *self_guid = g_str_has_prefix(self, "orgid:") ? self + 6 : self;
-		const gchar *buddy_name = purple_buddy_get_name(buddy);
 
 		gchar *self_guid_escaped = g_strdup(purple_url_encode(self_guid));
 		//https://teams.microsoft.com/api/mt/apac/beta/users/.../profilepicturev2?displayname=Eion%20Robb&size=HR96x96
@@ -176,7 +207,7 @@ teams_get_icon_now(PurpleBuddy *buddy)
 	request = purple_http_request_new(url);
 	purple_http_request_set_keepalive_pool(request, sa->keepalive_pool);
 	purple_http_request_set_max_redirects(request, 0);
-	purple_http_request_set_timeout(request, 120);
+	purple_http_request_set_timeout(request, 30);
 	
 	// Uses a cookie instead of the Authorization header cos a browser wouldn't request an image with an auth header
 	if (g_str_has_prefix(url, "https://" TEAMS_BASE_ORIGIN_HOST "/api/mt/") && strstr(url, "/profilepicturev2")) {
@@ -202,12 +233,54 @@ teams_get_icon(PurpleBuddy *buddy)
 	if (icon_download_queue == NULL) {
 		icon_download_queue = g_queue_new();
 	}
+	if (icon_queue_set == NULL) {
+		icon_queue_set = g_hash_table_new(g_direct_hash, g_direct_equal);
+	}
+
+	// Don't queue the same buddy more than once. Many API callbacks (searchV2,
+	// fetchShortProfile, fetchFederated, fetchTflConsumers, contactsv3, ...)
+	// call teams_get_icon() for the same buddy. This can produce several
+	// concurrent HTTP downloads that race to overwrite the same PurpleBuddyIcon
+	// slot, which corrupts the icon-store metadata.
+	if (g_hash_table_lookup(icon_queue_set, buddy)) {
+		return;
+	}
 
 	g_queue_push_tail(icon_download_queue, buddy);
+	g_hash_table_insert(icon_queue_set, buddy, GUINT_TO_POINTER(TRUE));
 
 	// Start the single queue-processing timer if it isn't already running.
 	if (icon_queue_timer_id == 0) {
 		icon_queue_timer_id = g_timeout_add(100, teams_process_icon_queue, NULL);
+	}
+}
+
+void
+teams_flush_icon_queue_for_account(PurpleAccount *account)
+{
+	if (icon_download_queue == NULL) {
+		return;
+	}
+
+	// Walk the queue and remove every entry that belongs to this account
+	GList *entry = icon_download_queue->head;
+	while (entry != NULL) {
+		GList *next = entry->next;
+		PurpleBuddy *b = entry->data;
+		if (b && purple_buddy_get_account(b) == account) {
+			if (icon_queue_set != NULL) {
+				g_hash_table_remove(icon_queue_set, b);
+			}
+			g_queue_delete_link(icon_download_queue, entry);
+		}
+		entry = next;
+	}
+
+	// If the queue is now empty, stop the timer so it does not fire
+	// with an empty queue (which would be safe but wasteful).
+	if (g_queue_is_empty(icon_download_queue) && icon_queue_timer_id != 0) {
+		g_source_remove(icon_queue_timer_id);
+		icon_queue_timer_id = 0;
 	}
 }
 
@@ -1371,6 +1444,10 @@ teams_process_profile_batch(gpointer user_data)
 		PurpleBuddy *buddy;
 		TeamsBuddy *sbuddy;
 
+		if (!username || !*username) {
+			continue;
+		}
+
 		buddy = purple_blist_find_buddy(sa->account, username);
 		if (!buddy) {
 			buddy = purple_buddy_new(sa->account, username, NULL);
@@ -1776,10 +1853,14 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 	guint index, length;
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
+	GSList *users_to_subscribe = NULL;
 	PurpleBuddy *buddy;
-	
+
+	if (node == NULL)
+		return;
+
 	obj = json_node_get_object(node);
-	
+
 	// Group chats
 	chats = json_object_get_array_member(obj, "chats");
 	length = json_array_get_length(chats);
@@ -1802,6 +1883,8 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 		
 		if (is_one_on_one) {
 			JsonArray *members = json_object_get_array_member(chat, "members");
+			guint members_len = json_array_get_length(members);
+			if (members_len < 1) continue;
 			JsonObject *member = json_array_get_object_element(members, 0);
 			const gchar *mri = json_object_get_string_member(member, "mri");
 			if (mri == NULL) continue;
@@ -1809,16 +1892,23 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 			
 			if (teams_is_user_self(sa, buddyid)) {
 				// There were two in the bed and the little one said....
-				member = json_array_get_object_element(members, 1);
-				if (member == NULL) {
+				if (members_len < 2) {
 					// ... goodnight!
 					continue;
 				}
+				member = json_array_get_object_element(members, 1);
+				if (member == NULL) {
+					continue;
+				}
 				mri = json_object_get_string_member(member, "mri");
+				if (mri == NULL) continue;
 				buddyid = teams_strip_user_prefix(mri);
 			}
-			
+
+			if (!buddyid || !*buddyid) continue;
+
 			users_to_fetch = g_slist_prepend(users_to_fetch, g_strdup(buddyid));
+			users_to_subscribe = g_slist_prepend(users_to_subscribe, g_strdup(buddyid));
 			
 			//Create an array of one to one mappings for IMs
 			if (!g_hash_table_contains(sa->buddy_to_chat_lookup, buddyid)) {
@@ -1857,13 +1947,13 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 			if (!g_str_has_prefix(id, "19:meeting_")) {
 				JsonArray *members = json_object_get_array_member(chat, "members");
 				guint members_index, members_length = json_array_get_length(members);
-				
+
 				for(members_index = 0; members_index < members_length; members_index++)
 				{
 					JsonObject *member = json_array_get_object_element(members, members_index);
 					const gchar *mri = json_object_get_string_member(member, "mri");
 					const gchar *buddyid = teams_strip_user_prefix(mri);
-					
+
 					users_to_fetch = g_slist_prepend(users_to_fetch, g_strdup(buddyid));
 				}
 			}
@@ -1882,8 +1972,12 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 	if (users_to_fetch)
 	{
 		teams_get_friend_profiles(sa, users_to_fetch);
-		teams_subscribe_to_contact_status(sa, users_to_fetch);
 		g_slist_free_full(users_to_fetch, g_free);
+	}
+	if (users_to_subscribe)
+	{
+		teams_subscribe_to_contact_status(sa, users_to_subscribe);
+		g_slist_free_full(users_to_subscribe, g_free);
 	}
 }
 
@@ -1924,7 +2018,10 @@ teams_get_friend_suggestions_cb(TeamsAccount *sa, JsonNode *node, gpointer user_
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
 	guint index, length;
-	
+
+	if (node == NULL)
+		return;
+
 	obj = json_node_get_object(node);
 	groups = json_object_get_array_member(obj, "Groups");
 	firstgroup = json_array_get_object_element(groups, 0);
@@ -1943,6 +2040,7 @@ teams_get_friend_suggestions_cb(TeamsAccount *sa, JsonNode *node, gpointer user_
 		const gchar *id;
 		
 		id = teams_strip_user_prefix(mri);
+		if (!id || !*id) continue;
 		
 		buddy = purple_blist_find_buddy(sa->account, id);
 		if (!buddy)
@@ -2002,7 +2100,10 @@ teams_get_workingwith_cb(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
 	guint index, length;
-	
+
+	if (node == NULL)
+		return;
+
 	obj = json_node_get_object(node);
 	contacts = json_object_get_array_member(obj, "value");
 	length = json_array_get_length(contacts);
@@ -2013,6 +2114,8 @@ teams_get_workingwith_cb(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 		const gchar *aadObjectId = json_object_get_string_member(contact, "aadObjectId");
 		const gchar *full_name = json_object_get_string_member(contact, "fullName");
 		
+		if (!aadObjectId || !*aadObjectId) continue;
+
 		PurpleBuddy *buddy;
 		gchar *id;
 		
@@ -2066,7 +2169,10 @@ teams_get_friend_list_cb(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
 	guint index, length;
-	
+
+	if (node == NULL)
+		return;
+
 	obj = json_node_get_object(node);
 	contacts = json_object_get_array_member(obj, "value");
 	length = json_array_get_length(contacts);
@@ -2095,6 +2201,7 @@ teams_get_friend_list_cb(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 		const gchar *id;
 		
 		id = teams_strip_user_prefix(mri);
+		if (!id || !*id) continue;
 
 		if (!display_name && !firstname && !surname && json_object_has_member(contact, "name")) {
 			JsonObject *name = json_object_get_object_member(contact, "name");
@@ -2174,7 +2281,10 @@ teams_get_buddylist_cb(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
 	guint index, length;
-	
+
+	if (node == NULL)
+		return;
+
 	obj = json_node_get_object(node);
 	values = json_object_get_array_member(obj, "value");
 	length = json_array_get_length(values);
@@ -2196,6 +2306,7 @@ teams_get_buddylist_cb(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 			const gchar *id;
 		
 			id = teams_strip_user_prefix(mri);
+			if (!id || !*id) continue;
 			
 			buddy = purple_blist_find_buddy(sa->account, id);
 			if (!buddy)
@@ -2482,7 +2593,10 @@ teams_got_authrequests(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	JsonArray *invite_list;
 	guint index, length;
 	time_t latest_timestamp = 0;
-	
+
+	if (node == NULL)
+		return;
+
 	requests = json_node_get_object(node);
 	invite_list = json_object_get_array_member(requests, "invite_list");
 	length = json_array_get_length(invite_list);

--- a/teams_contacts.c
+++ b/teams_contacts.c
@@ -77,6 +77,37 @@ typedef struct {
 
 static guint active_icon_downloads = 0;
 
+static void teams_get_icon_now(PurpleBuddy *buddy);
+
+static GQueue    *icon_download_queue = NULL;
+static GHashTable *icon_queue_set     = NULL;
+static guint      icon_queue_timer_id = 0;
+
+static gboolean
+teams_process_icon_queue(gpointer data)
+{
+	if (icon_download_queue == NULL || g_queue_is_empty(icon_download_queue)) {
+		icon_queue_timer_id = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	// Respect the concurrent download cap and try again next tick.
+	if (active_icon_downloads > 4) {
+		return G_SOURCE_CONTINUE;
+	}
+
+	PurpleBuddy *buddy = g_queue_pop_head(icon_download_queue);
+	if (buddy) {
+		teams_get_icon_now(buddy);
+	}
+
+	if (g_queue_is_empty(icon_download_queue)) {
+		icon_queue_timer_id = 0;
+		return G_SOURCE_REMOVE;
+	}
+	return G_SOURCE_CONTINUE;
+}
+
 static void
 teams_get_icon_cb(PurpleHttpConnection *http_conn, PurpleHttpResponse *response, gpointer user_data)
 {
@@ -87,7 +118,7 @@ teams_get_icon_cb(PurpleHttpConnection *http_conn, PurpleHttpResponse *response,
 	gsize len;
 	
 	active_icon_downloads--;
-	
+
 	if (!buddy || !purple_http_response_is_successful(response)) {
 		return;
 	}
@@ -161,27 +192,23 @@ teams_get_icon_now(PurpleBuddy *buddy)
 	active_icon_downloads++;
 }
 
-static gboolean
-teams_get_icon_queuepop(gpointer data)
-{
-	PurpleBuddy *buddy = data;
-	
-	// Only allow 4 simultaneous downloads
-	if (active_icon_downloads > 4)
-		return TRUE;
-	
-	teams_get_icon_now(buddy);
-	return FALSE;
-}
-
 void
 teams_get_icon(PurpleBuddy *buddy)
 {
 	if (!buddy) return;
 	if (purple_strequal(purple_core_get_ui(), "BitlBee"))
 		return;
-	
-	g_timeout_add(100, teams_get_icon_queuepop, (gpointer)buddy);
+
+	if (icon_download_queue == NULL) {
+		icon_download_queue = g_queue_new();
+	}
+
+	g_queue_push_tail(icon_download_queue, buddy);
+
+	// Start the single queue-processing timer if it isn't already running.
+	if (icon_queue_timer_id == 0) {
+		icon_queue_timer_id = g_timeout_add(100, teams_process_icon_queue, NULL);
+	}
 }
 
 typedef struct SkypeImgMsgContext_ {
@@ -1303,30 +1330,37 @@ teams_set_work_location_action(PurpleProtocolAction *action)
 	teams_post_or_get(sa, TEAMS_METHOD_GET | TEAMS_METHOD_SSL, TEAMS_BASE_ORIGIN_HOST, url, NULL, teams_swl_got_building_info, NULL, TRUE);
 }
 
-static void
-teams_got_friend_profiles(TeamsAccount *sa, JsonNode *node, gpointer user_data)
-{
-	JsonObject *obj;
+// Number of friend profile entries to process per idle tick before yielding to
+// the GTK main loop. Keeps the UI responsive during large profile fetches.
+#define TEAMS_PROFILE_BATCH_SIZE 20
+
+typedef struct {
+	PurpleConnection *pc;
 	JsonArray *contacts;
-	PurpleBuddy *buddy;
-	TeamsBuddy *sbuddy;
-	gint index, length;
-	PurpleGroup *group = teams_get_blist_group(sa);
-	
-	if (node == NULL)
-		return;
-	obj = json_node_get_object(node);
-	contacts = json_object_get_array_member(obj, "value");
-	if (contacts == NULL) {
-		// Different array key for the fetchTflConsumers call
-		contacts = json_object_get_array_member(obj, "resolvedUsers");
+	gint next_index;
+	gint length;
+} TeamsBatchProfileData;
+
+static gboolean
+teams_process_profile_batch(gpointer user_data)
+{
+	TeamsBatchProfileData *data = user_data;
+
+	if (!PURPLE_IS_CONNECTION(data->pc)) {
+		// Connection was dropped while we were idle, clean up and stop
+		json_array_unref(data->contacts);
+		g_free(data);
+		return G_SOURCE_REMOVE;
 	}
-	length = json_array_get_length(contacts);
-	
-	for(index = 0; index < length; index++)
-	{
-		JsonObject *contact = json_array_get_object_element(contacts, index);
-		
+
+	TeamsAccount *sa = purple_connection_get_protocol_data(data->pc);
+	PurpleGroup *group = teams_get_blist_group(sa);
+	gint end_index = MIN(data->next_index + TEAMS_PROFILE_BATCH_SIZE, data->length);
+	gint index;
+
+	for (index = data->next_index; index < end_index; index++) {
+		JsonObject *contact = json_array_get_object_element(data->contacts, index);
+
 		const gchar *mri = json_object_get_string_member(contact, "mri");
 		const gchar *username = teams_strip_user_prefix(mri);
 		const gchar *new_avatar;
@@ -1334,14 +1368,15 @@ teams_got_friend_profiles(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 		const gchar *givenName = json_object_get_string_member(contact, "givenName");
 		const gchar *tenantName = json_object_get_string_member(contact, "tenantName");
 		const gchar *userType = json_object_get_string_member(contact, "type");
-		
+		PurpleBuddy *buddy;
+		TeamsBuddy *sbuddy;
+
 		buddy = purple_blist_find_buddy(sa->account, username);
-		if (!buddy)
-		{
+		if (!buddy) {
 			buddy = purple_buddy_new(sa->account, username, NULL);
 			purple_blist_add_buddy(buddy, NULL, group, NULL);
 		}
-		
+
 		sbuddy = purple_buddy_get_protocol_data(buddy);
 		if (sbuddy == NULL) {
 			sbuddy = g_new0(TeamsBuddy, 1);
@@ -1349,24 +1384,24 @@ teams_got_friend_profiles(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 			sbuddy->skypename = g_strdup(username);
 			sbuddy->sa = sa;
 		}
-		
+
 		if (displayName && *displayName) {
-			g_free(sbuddy->display_name); 
+			g_free(sbuddy->display_name);
 			sbuddy->display_name = g_strdup(displayName);
 			if (!purple_strequal(purple_buddy_get_local_alias(buddy), sbuddy->display_name)) {
 				purple_serv_got_alias(sa->pc, username, sbuddy->display_name);
 			}
 		}
-		
+
 		if (givenName && *givenName && !purple_strequal(json_object_get_string_member(contact, "email"), givenName)) {
 			g_free(sbuddy->fullname);
 			if (json_object_has_member(contact, "surname")) {
 				gchar *fullname = g_strconcat(givenName, " ", json_object_get_string_member(contact, "surname"), NULL);
-				
+
 				if (fullname && *fullname) {
 					purple_buddy_set_server_alias(buddy, fullname);
 				}
-				
+
 				sbuddy->fullname = fullname;
 			} else {
 				purple_buddy_set_server_alias(buddy, givenName);
@@ -1385,7 +1420,7 @@ teams_got_friend_profiles(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 			g_free(sbuddy->user_type);
 			sbuddy->user_type = g_strdup(userType);
 		}
-		
+
 		// Only bots have images
 		new_avatar = json_object_get_string_member(contact, "imageUri");
 		if (new_avatar && *new_avatar && (!sbuddy->avatar_url || !g_str_equal(sbuddy->avatar_url, new_avatar))) {
@@ -1394,6 +1429,44 @@ teams_got_friend_profiles(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 		}
 		teams_get_icon(buddy);
 	}
+
+	data->next_index = end_index;
+
+	if (data->next_index >= data->length) {
+		// All entries processed
+		json_array_unref(data->contacts);
+		g_free(data);
+		return G_SOURCE_REMOVE;
+	}
+
+	// More entries remain. Yield to the main loop and continue next tick.
+	return G_SOURCE_CONTINUE;
+}
+
+static void
+teams_got_friend_profiles(TeamsAccount *sa, JsonNode *node, gpointer user_data)
+{
+	JsonObject *obj;
+	JsonArray *contacts;
+
+	if (node == NULL)
+		return;
+	obj = json_node_get_object(node);
+	contacts = json_object_get_array_member(obj, "value");
+	if (contacts == NULL) {
+		contacts = json_object_get_array_member(obj, "resolvedUsers");
+	}
+	if (contacts == NULL || json_array_get_length(contacts) == 0) {
+		return;
+	}
+
+	TeamsBatchProfileData *data = g_new0(TeamsBatchProfileData, 1);
+	data->pc = sa->pc;
+	data->contacts = json_array_ref(contacts);
+	data->next_index = 0;
+	data->length = (gint)json_array_get_length(contacts);
+
+	g_idle_add(teams_process_profile_batch, data);
 }
 
 void
@@ -1417,6 +1490,10 @@ teams_get_friend_profiles(TeamsAccount *sa, GSList *contacts)
 	do {
 		user_prefix = teams_user_url_prefix(cur->data);
 		if (g_str_equal(user_prefix, "8:") && strncmp(cur->data, "orgid:", 6) != 0) continue;
+		// Skip contacts whose profiles have already been fetched to avoid duplicate
+		// HTTP requests and the server-side throttling they cause.
+		if (g_hash_table_lookup(sa->fetched_profiles, (gconstpointer) cur->data) != NULL) continue;
+		g_hash_table_insert(sa->fetched_profiles, g_strdup(cur->data), GUINT_TO_POINTER(TRUE));
 		g_string_append_printf(postdata, ",\"%s%s\"", user_prefix, (gchar *) cur->data);
 		count++;
 
@@ -1749,16 +1826,18 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 				
 			}
 			
-			JsonArray *members = json_object_get_array_member(chat, "members");
-			guint members_index, members_length = json_array_get_length(members);
-			
-			for(members_index = 0; members_index < members_length; members_index++)
-			{
-				JsonObject *member = json_array_get_object_element(members, members_index);
-				const gchar *mri = json_object_get_string_member(member, "mri");
-				const gchar *buddyid = teams_strip_user_prefix(mri);
+			if (!g_str_has_prefix(id, "19:meeting_")) {
+				JsonArray *members = json_object_get_array_member(chat, "members");
+				guint members_index, members_length = json_array_get_length(members);
 				
-				users_to_fetch = g_slist_prepend(users_to_fetch, g_strdup(buddyid));
+				for(members_index = 0; members_index < members_length; members_index++)
+				{
+					JsonObject *member = json_array_get_object_element(members, members_index);
+					const gchar *mri = json_object_get_string_member(member, "mri");
+					const gchar *buddyid = teams_strip_user_prefix(mri);
+					
+					users_to_fetch = g_slist_prepend(users_to_fetch, g_strdup(buddyid));
+				}
 			}
 		}
 	}

--- a/teams_contacts.c
+++ b/teams_contacts.c
@@ -1735,6 +1735,30 @@ teams_find_chat(PurpleAccount *account, const char *id)
 	return teams_find_chat_from_node(account, id, purple_blist_get_root());
 }
 
+static void
+teams_purge_meeting_chats_from_blist(TeamsAccount *sa)
+{
+	if (!purple_account_get_bool(sa->account, "hide_meeting_chats", FALSE)) {
+		return;
+	}
+
+	PurpleBlistNode *node = purple_blist_get_root();
+	while (node != NULL) {
+		PurpleBlistNode *next = purple_blist_node_next(node, TRUE);
+		if (PURPLE_IS_CHAT(node)) {
+			PurpleChat *chat = PURPLE_CHAT(node);
+			if (purple_chat_get_account(chat) == sa->account) {
+				GHashTable *components = purple_chat_get_components(chat);
+				const gchar *chat_id = g_hash_table_lookup(components, "chatname");
+				if (chat_id && g_str_has_prefix(chat_id, "19:meeting_")) {
+					purple_blist_remove_chat(chat);
+				}
+			}
+		}
+		node = next;
+	}
+}
+
 
 PurpleChat *
 teams_find_chat_in_group(PurpleAccount *account, const char *id, PurpleGroup *group)
@@ -1813,6 +1837,10 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 		} else {
 			const gchar *title = json_object_get_string_member(chat, "title");
 			PurpleChat *purple_chat = teams_find_chat(sa->account, id);
+			
+			if (g_str_has_prefix(id, "19:meeting_") && purple_account_get_bool(sa->account, "hide_meeting_chats", FALSE)) {
+				continue;
+			}
 			
 			if (purple_chat == NULL) {
 				GHashTable *components = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
@@ -2227,6 +2255,9 @@ teams_get_friend_list(TeamsAccount *sa)
 	if (!PURPLE_IS_CONNECTION(pc)) {
 		return FALSE;
 	}
+
+	// Remove any meeting chats that were persisted from previous sessions
+	teams_purge_meeting_chats_from_blist(sa);
 
 	const gchar *url = TEAMS_PROFILES_PREFIX "users/searchV2?includeDLs=true&includeBots=true&enableGuest=true&source=newChat&skypeTeamsInfo=true";
 	

--- a/teams_contacts.c
+++ b/teams_contacts.c
@@ -79,6 +79,7 @@ static guint active_icon_downloads = 0;
 
 static void teams_get_icon_now(PurpleBuddy *buddy);
 
+static GHashTable *icon_queue_set = NULL;
 static GQueue *icon_download_queue = NULL;
 static guint   icon_queue_timer_id = 0;
 

--- a/teams_contacts.c
+++ b/teams_contacts.c
@@ -1420,7 +1420,7 @@ teams_process_profile_batch(gpointer user_data)
 {
 	TeamsBatchProfileData *data = user_data;
 
-	if (!PURPLE_IS_CONNECTION(data->pc)) {
+	if (!PURPLE_IS_CONNECTION(data->pc) || !purple_connection_get_protocol_data(data->pc)) {
 		// Connection was dropped while we were idle, clean up and stop
 		json_array_unref(data->contacts);
 		g_free(data);
@@ -1828,7 +1828,7 @@ teams_purge_meeting_chats_from_blist(TeamsAccount *sa)
 			if (purple_chat_get_account(chat) == sa->account) {
 				GHashTable *components = purple_chat_get_components(chat);
 				const gchar *chat_id = g_hash_table_lookup(components, "chatname");
-				if (chat_id && g_str_has_prefix(chat_id, "19:meeting_")) {
+				if (TEAMS_CHAT_IS_MEETING(chat_id)) {
 					purple_blist_remove_chat(chat);
 				}
 			}
@@ -1929,7 +1929,7 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 			const gchar *title = json_object_get_string_member(chat, "title");
 			PurpleChat *purple_chat = teams_find_chat(sa->account, id);
 			
-			if (g_str_has_prefix(id, "19:meeting_") && purple_account_get_bool(sa->account, "hide_meeting_chats", FALSE)) {
+			if (TEAMS_CHAT_IS_MEETING(id) && purple_account_get_bool(sa->account, "hide_meeting_chats", FALSE)) {
 				continue;
 			}
 			
@@ -1945,7 +1945,7 @@ teams_get_friend_list_teams_cb(TeamsAccount *sa, JsonNode *node, gpointer user_d
 				
 			}
 			
-			if (!g_str_has_prefix(id, "19:meeting_")) {
+			if (!TEAMS_CHAT_IS_MEETING(id)) {
 				JsonArray *members = json_object_get_array_member(chat, "members");
 				guint members_index, members_length = json_array_get_length(members);
 

--- a/teams_contacts.h
+++ b/teams_contacts.h
@@ -22,6 +22,7 @@
 #include "libteams.h"
 
 void teams_get_icon(PurpleBuddy *buddy);
+void teams_flush_icon_queue_for_account(PurpleAccount *account);
 void teams_download_uri_to_conv(TeamsAccount *sa, const gchar *uri, PurpleConversation *conv, time_t ts, const gchar* from);
 void teams_download_video_message(TeamsAccount *sa, const gchar *sid, PurpleConversation *conv);
 void teams_download_moji_to_conv(TeamsAccount *sa, const gchar *text, const gchar *url_thumbnail, PurpleConversation *conv, time_t ts, const gchar* from);

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -1682,7 +1682,6 @@ teams_drain_presence_queue(gpointer user_data)
 
 	if (!PURPLE_IS_CONNECTION(sa->pc)) {
 		// If the connection has dropped discard all pending messages and stop.
-		g_hash_table_remove_all(sa->presence_mri_index);
 		while (!g_queue_is_empty(sa->pending_presences)) {
 			json_object_unref(g_queue_pop_head(sa->pending_presences));
 		}
@@ -1694,9 +1693,20 @@ teams_drain_presence_queue(gpointer user_data)
 	GSList *users_to_fetch = NULL;
 	gint count = 0;
 
+	// Time box the drain so that the GTK main loop always gets back control
+	// within ~20 ms.  Buddy-list redraws are expensive when the list is large.
+	// The time box prevents the 50 ms timer from queuing up faster than it drains.
+	gint64 deadline = g_get_monotonic_time() + 20000; // 20 ms from now
+
 	while (!g_queue_is_empty(sa->pending_presences) && count < TEAMS_PRESENCE_BATCH_SIZE) {
 		JsonObject *response = g_queue_pop_head(sa->pending_presences);
 		count++;
+
+		// Remove from the deduplication index now that we are processing this entry.
+		const gchar *index_mri = json_object_get_string_member(response, "mri");
+		if (index_mri) {
+			g_hash_table_remove(sa->presence_mri_index, index_mri);
+		}
 
 		JsonObject *presence = json_object_get_object_member(response, "presence");
 		const gchar *mri = json_object_get_string_member(response, "mri");
@@ -1816,12 +1826,46 @@ teams_drain_presence_queue(gpointer user_data)
 			status_message = json_object_get_string_member(note, "message");
 		}
 
-		purple_protocol_got_user_status(sa->account, from, availability, "message", status_message, NULL);
+		// Skip the expensive purple_protocol_got_user_status() and buddy-list
+		// redraw when the visible state won't change.  libpurple's
+		// purple_prpl_got_user_status() always fires "buddy-status-changed" even
+		// for no-op transitions (ex: offline -> offline), triggering a full GTK
+		// buddy-list re-sort.  At startup with "Show Offline Buddies" enabled, this
+		// could otherwise fire hundreds of times for contacts that remain offline,
+		// locking the UI.
+		gboolean should_update_availability = TRUE;
+		PurpleBuddy *existing = purple_blist_find_buddy(sa->account, from);
+		if (existing != NULL) {
+			PurplePresence *epres = purple_buddy_get_presence(existing);
+			gboolean currently_online = purple_presence_is_online(epres);
+			gboolean new_is_offline = (purple_strequal(availability, "Offline") ||
+			                          purple_strequal(availability, "PresenceUnknown"));
+			if (!currently_online && new_is_offline) {
+				// Both old and new are offline. Only push the update if the
+				// buddy status actually changed.
+				PurpleStatus *estat = purple_presence_get_active_status(epres);
+				const gchar *current_msg = estat ?
+				    purple_status_get_attr_string(estat, "message") : NULL;
+				if (g_strcmp0(current_msg, status_message) == 0) {
+					should_update_availability = FALSE;
+				}
+			}
+		}
 
-		gboolean is_idle = strstr(availability, "Idle") != NULL;
-		purple_prpl_got_user_idle(sa->account, from, is_idle, 0);
+		if (should_update_availability) {
+			purple_protocol_got_user_status(sa->account, from, availability, "message", status_message, NULL);
+
+			gboolean is_idle = strstr(availability, "Idle") != NULL;
+			purple_prpl_got_user_idle(sa->account, from, is_idle, 0);
+		}
 
 		json_object_unref(response);
+
+		// Yield if we have been in this callback for more than 20 ms so that
+		// the GTK main loop can process paint and input events before the next
+		// batch is processed.
+		if (g_get_monotonic_time() > deadline)
+			break;
 	}
 
 	if (users_to_fetch) {
@@ -1846,12 +1890,45 @@ teams_got_contact_statuses(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 		return;
 	}
 
-	// Enqueue all entries onto the shared presence queue.
+	// Enqueue all entries onto the shared presence queue, deduplicating by MRI.
+	// If an entry for the same MRI is already waiting in the queue, overwrite
+	// it with the newer payload since only the most recent status matters.
+	// This caps queue depth at the number of unique contacts rather than at the
+	// number of incoming API responses, preventing unbounded queue growth when
+	// updates arrive faster than the drain can process them.
 	guint len = json_array_get_length(responses);
 	for (guint i = 0; i < len; i++) {
 		JsonObject *resp = json_array_get_object_element(responses, i);
-		if (resp != NULL) {
+		if (resp == NULL) continue;
+
+		const gchar *mri = json_object_get_string_member(resp, "mri");
+		if (!mri || !*mri) continue;
+
+		// PSTN (4:) contacts are telephone numbers, not IM buddies.
+		if (g_str_has_prefix(mri, "4:")) continue;
+
+		// Skip if the etag is unchanged since the last drain.
+		// The server resends all subscribed contacts' presence on reconnect
+		// even when nothing changed; this avoids queuing the entire buddy
+		// list when there are no actual status changes.
+		const gchar *etag = json_object_get_string_member(resp, "etag");
+		if (etag && *etag) {
+			const gchar *cached_etag = g_hash_table_lookup(sa->presence_etag_cache, mri);
+			if (cached_etag && g_str_equal(cached_etag, etag)) continue;
+		}
+
+		// If an entry for this MRI is already queued, overwrite its data in-place.
+		// The GList node stays at its current position in the FIFO so ordering is
+		// preserved, only the payload is updated.
+		GList *existing_node = g_hash_table_lookup(sa->presence_mri_index, mri);
+		if (existing_node != NULL) {
+			json_object_unref(existing_node->data);
+			existing_node->data = json_object_ref(resp);
+		} else {
 			g_queue_push_tail(sa->pending_presences, json_object_ref(resp));
+			// Store the tail GList node for O(1) future in-place updates.
+			g_hash_table_insert(sa->presence_mri_index, g_strdup(mri),
+			                    sa->pending_presences->tail);
 		}
 	}
 

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -1414,6 +1414,7 @@ teams_got_thread_users(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	gint length, index;
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
+	gboolean is_meeting_chat = g_str_has_prefix(chatname, "19:meeting_");
 	
 	chatconv = purple_conversations_find_chat_with_account(chatname, sa->account);
 	g_free(chatname);
@@ -1477,7 +1478,9 @@ teams_got_thread_users(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	}
 	
 	teams_get_friend_profiles(sa, users_to_fetch);
-	teams_subscribe_to_contact_status(sa, users_to_fetch);
+	if (!is_meeting_chat) {
+		teams_subscribe_to_contact_status(sa, users_to_fetch);
+	}
 	g_slist_free_full(users_to_fetch, g_free);
 }
 
@@ -1664,121 +1667,191 @@ teams_unsubscribe_from_contact_status(TeamsAccount *sa, const gchar *who)
 	g_free(url);
 }
 
+// Number of presence entries to process per idle tick before yielding to the
+// GTK main loop. This keeps the UI responsive during large snapshot updates.
+#define TEAMS_PRESENCE_BATCH_SIZE 20
+
+// Drains up to TEAMS_PRESENCE_BATCH_SIZE entries from the shared presence queue
+// per idle tick.
+//
+// Because all incoming responses feed into one queue there is only a single
+// idle callback active at a time. Therefore, the main loop will always regain
+// control after processing up to TEAMS_PRESENCE_BATCH_SIZE status updates
+// regardless of how many API responses arrive concurrently.
+static gboolean
+teams_drain_presence_queue(gpointer user_data)
+{
+	TeamsAccount *sa = user_data;
+
+	if (!PURPLE_IS_CONNECTION(sa->pc)) {
+		// If the connection has dropped discard all pending messages and stop.
+		g_hash_table_remove_all(sa->presence_mri_index);
+		while (!g_queue_is_empty(sa->pending_presences)) {
+			json_object_unref(g_queue_pop_head(sa->pending_presences));
+		}
+		sa->presence_drain_source = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	PurpleGroup *group = teams_get_blist_group(sa);
+	GSList *users_to_fetch = NULL;
+	gint count = 0;
+
+	while (!g_queue_is_empty(sa->pending_presences) && count < TEAMS_PRESENCE_BATCH_SIZE) {
+		JsonObject *response = g_queue_pop_head(sa->pending_presences);
+		count++;
+
+		JsonObject *presence = json_object_get_object_member(response, "presence");
+		const gchar *mri = json_object_get_string_member(response, "mri");
+
+		if (presence == NULL || mri == NULL) {
+			json_object_unref(response);
+			continue;
+		}
+
+		const gchar *availability = json_object_get_string_member(presence, "availability");
+		const gchar *from = teams_strip_user_prefix(mri);
+
+		if (!from || !availability) {
+			json_object_unref(response);
+			continue;
+		}
+
+		if (!purple_blist_find_buddy(sa->account, from)) {
+			if (!teams_is_user_self(sa, from)) {
+				purple_blist_add_buddy(purple_buddy_new(sa->account, from, NULL), NULL, group, NULL);
+				users_to_fetch = g_slist_prepend(users_to_fetch, g_strdup(from));
+			}
+		}
+		//TODO note/OOOnote -> status message
+		/*
+			"presence": {
+				"sourceNetwork": "SameEnterprise",
+				"note": {
+					"message": "<p>hi :)</p>",
+					"publishTime": "2025-12-23T08:59:24.2293971Z",
+					"expiry": "2025-12-23T10:59:59.999Z"
+				},
+				"workLocation": {
+					"location": "Office",
+					"expiry": "2025-12-23T10:59:59.9999999Z",
+					"isForced": true,
+					"locationSource": "ForcedLocation",
+					"approximateDetails": {
+						"id": "12345678-1234-4321-abcd-1234567890ab",
+						"name": "Building A - Floor 3",
+						"idType": "Directory"
+					},
+					"maxShared": "Specific"
+				},
+				"calendarData": {
+					"outOfOfficeNote": {
+						"message": "I am on leave - returning 19th April",
+						"publishTime": "2022-04-14T08:02:23.5053937Z",
+						"expiry": "2022-04-19T07:00:00Z"
+					},
+					"isOutOfOffice": true
+				},
+				"capabilities": [],
+				"availability": "Away",
+				"activity": "Away",
+				"lastActiveTime": "2022-04-14T04:41:35.67Z",
+				"deviceType": "Desktop"
+			},
+			"etagMatch": false,
+			"etag": "A0072086544",
+			"status": 20000
+		*/
+
+		// Skip status updates whose presence hasn't changed since we last
+		// processed them. Each entry carries an etag that the server increments
+		// whenever the contact's presence changes.
+		const gchar *etag = json_object_get_string_member(response, "etag");
+		if (etag && *etag) {
+			const gchar *cached_etag = g_hash_table_lookup(sa->presence_etag_cache, mri);
+			if (cached_etag && g_str_equal(cached_etag, etag)) {
+				json_object_unref(response);
+				continue;
+			}
+			g_hash_table_insert(sa->presence_etag_cache, g_strdup(mri), g_strdup(etag));
+		}
+
+		JsonObject *calendarData = json_object_get_object_member(presence, "calendarData");
+		if (calendarData != NULL) {
+			gboolean isOutOfOffice = json_object_get_boolean_member(calendarData, "isOutOfOffice");
+			if (isOutOfOffice) {
+				JsonObject *outOfOfficeNote = json_object_get_object_member(calendarData, "outOfOfficeNote");
+				const gchar *message = json_object_get_string_member(outOfOfficeNote, "message");
+				purple_protocol_got_user_status(sa->account, from, TEAMS_OOO_STATUS_ID, "message", message, NULL);
+			} else {
+				purple_protocol_deactivate_user_status(sa->account, from, TEAMS_OOO_STATUS_ID);
+			}
+		}
+
+		JsonObject *workLocation = json_object_get_object_member(presence, "workLocation");
+		if (workLocation != NULL) {
+			const gchar *location_name = NULL;
+			const gchar *location = json_object_get_string_member(workLocation, "location");
+			JsonObject *approximateDetails = json_object_get_object_member(workLocation, "approximateDetails");
+			if (approximateDetails != NULL) {
+				const gchar *name = json_object_get_string_member(approximateDetails, "name");
+				if (name != NULL && *name) {
+					location_name = name;
+				}
+			}
+			purple_protocol_got_user_status(sa->account, from, TEAMS_WORK_LOCATION_STATUS_ID, "location", location, "location_name", location_name, NULL);
+		} else {
+			purple_protocol_deactivate_user_status(sa->account, from, TEAMS_WORK_LOCATION_STATUS_ID);
+		}
+
+		JsonObject *note = json_object_get_object_member(presence, "note");
+		const gchar *status_message = NULL;
+		if (note != NULL) {
+			status_message = json_object_get_string_member(note, "message");
+		}
+
+		purple_protocol_got_user_status(sa->account, from, availability, "message", status_message, NULL);
+
+		gboolean is_idle = strstr(availability, "Idle") != NULL;
+		purple_prpl_got_user_idle(sa->account, from, is_idle, 0);
+
+		json_object_unref(response);
+	}
+
+	if (users_to_fetch) {
+		teams_get_friend_profiles(sa, users_to_fetch);
+		g_slist_free_full(users_to_fetch, g_free);
+	}
+
+	if (g_queue_is_empty(sa->pending_presences)) {
+		sa->presence_drain_source = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	return G_SOURCE_CONTINUE;
+}
+
 void
 teams_got_contact_statuses(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 {
-	PurpleGroup *group = teams_get_blist_group(sa);
 	JsonArray *responses = json_node_get_array(node);
-	GSList *users_to_fetch = NULL;
-	
-	if (responses != NULL) {
-		const gchar *from;
-		guint length = json_array_get_length(responses);
-		gint index;
-		
-		for(index = length - 1; index >= 0; index--)
-		{
-			JsonObject *response = json_array_get_object_element(responses, index);
-			JsonObject *presence = json_object_get_object_member(response, "presence");
-			const gchar *mri = json_object_get_string_member(response, "mri");
-			const gchar *availability = json_object_get_string_member(presence, "availability");
-			
-			from = teams_strip_user_prefix(mri);
-			g_return_if_fail(from);
-			
-			if (!purple_blist_find_buddy(sa->account, from))
-			{
-				if (!teams_is_user_self(sa, from)) {
-					purple_blist_add_buddy(purple_buddy_new(sa->account, from, NULL), NULL, group, NULL);
-					users_to_fetch = g_slist_prepend(users_to_fetch, g_strdup(from));
-				}
-			}
-			
-			//TODO note/OOOnote -> status message
-			/* 
-				"presence": {
-					"sourceNetwork": "SameEnterprise",
-					"note": {
-						"message": "<p>hi :)</p>",
-						"publishTime": "2025-12-23T08:59:24.2293971Z",
-						"expiry": "2025-12-23T10:59:59.999Z"
-					},
-					"workLocation": {
-						"location": "Office",
-						"expiry": "2025-12-23T10:59:59.9999999Z",
-						"isForced": true,
-						"locationSource": "ForcedLocation",
-						"approximateDetails": {
-							"id": "12345678-1234-4321-abcd-1234567890ab",
-							"name": "Building A - Floor 3",
-							"idType": "Directory"
-						},
-						"maxShared": "Specific"
-					},
-					"calendarData": {
-						"outOfOfficeNote": {
-							"message": "I am on leave - returning 19th April",
-							"publishTime": "2022-04-14T08:02:23.5053937Z",
-							"expiry": "2022-04-19T07:00:00Z"
-						},
-						"isOutOfOffice": true
-					},
-					"capabilities": [],
-					"availability": "Away",
-					"activity": "Away",
-					"lastActiveTime": "2022-04-14T04:41:35.67Z",
-					"deviceType": "Desktop"
-				},
-				"etagMatch": false,
-				"etag": "A0072086544",
-				"status": 20000
-			*/
 
-			JsonObject *calendarData = json_object_get_object_member(presence, "calendarData");
-			if (calendarData != NULL) {
-				gboolean isOutOfOffice = json_object_get_boolean_member(calendarData, "isOutOfOffice");
-				if (isOutOfOffice) {
-					JsonObject *outOfOfficeNote = json_object_get_object_member(calendarData, "outOfOfficeNote");
-					const gchar *message = json_object_get_string_member(outOfOfficeNote, "message");
-					purple_protocol_got_user_status(sa->account, from, TEAMS_OOO_STATUS_ID, "message", message, NULL);
-				} else {
-					purple_protocol_deactivate_user_status(sa->account, from, TEAMS_OOO_STATUS_ID);
-				}
-			}
+	if (responses == NULL || json_array_get_length(responses) == 0) {
+		return;
+	}
 
-			JsonObject *workLocation = json_object_get_object_member(presence, "workLocation");
-			if (workLocation != NULL) {
-				const gchar *location_name = NULL;
-				const gchar *location = json_object_get_string_member(workLocation, "location");
-				JsonObject *approximateDetails = json_object_get_object_member(workLocation, "approximateDetails");
-				if (approximateDetails != NULL) {
-					const gchar *name = json_object_get_string_member(approximateDetails, "name");
-					if (name != NULL && *name) {
-						location_name = name;
-					}
-				}
-				purple_protocol_got_user_status(sa->account, from, TEAMS_WORK_LOCATION_STATUS_ID, "location", location, "location_name", location_name, NULL);
-			} else {
-				purple_protocol_deactivate_user_status(sa->account, from, TEAMS_WORK_LOCATION_STATUS_ID);
-			}
-
-			JsonObject *note = json_object_get_object_member(presence, "note");
-			const gchar *status_message = NULL;
-			if (note != NULL) {
-				status_message = json_object_get_string_member(note, "message");
-			}
-
-			purple_protocol_got_user_status(sa->account, from, availability, "message", status_message, NULL);
-
-			gboolean is_idle = strstr(availability, "Idle") != NULL;
-			purple_prpl_got_user_idle(sa->account, from, is_idle, 0);
+	// Enqueue all entries onto the shared presence queue.
+	guint len = json_array_get_length(responses);
+	for (guint i = 0; i < len; i++) {
+		JsonObject *resp = json_array_get_object_element(responses, i);
+		if (resp != NULL) {
+			g_queue_push_tail(sa->pending_presences, json_object_ref(resp));
 		}
 	}
 
-	if (users_to_fetch)
-	{
-		teams_get_friend_profiles(sa, users_to_fetch);
-		g_slist_free_full(users_to_fetch, g_free);
+	// Start the drain callback only if it isn't already running.
+	if (sa->presence_drain_source == 0) {
+		sa->presence_drain_source = g_idle_add(teams_drain_presence_queue, sa);
 	}
 }
 
@@ -1832,6 +1905,64 @@ teams_lookup_contact_statuses(TeamsAccount *sa, GSList *contacts)
 		g_free(post);
 	}
 	json_array_unref(contacts_array);
+}
+
+// Drains sa->pending_subscription_contacts at a rate of 100 contacts per 50 ms.
+// Called by a recurring g_timeout_add timer. Returns G_SOURCE_REMOVE when the
+// queue is empty and G_SOURCE_CONTINUE to reschedule for the next batch.
+//
+// Spacing the HTTP calls out prevents the server from receiving all
+// subscription requests simultaneously, which could cause it to return the
+// presence of all subscribed contacts via the Trouter WebSocket all at once.
+static gboolean
+teams_send_subscription_batch(gpointer user_data)
+{
+	TeamsAccount *sa = user_data;
+
+	if (!PURPLE_CONNECTION_IS_VALID(sa->pc) || sa->trouter_surl == NULL ||
+			g_queue_is_empty(sa->pending_subscription_contacts)) {
+		sa->subscription_flush_timer = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	JsonArray *subscriptionsToAdd = json_array_new();
+	JsonArray *subscriptionsToRemove = json_array_new();
+	gchar *trouterUri = g_strconcat(sa->trouter_surl, "/TeamsUnifiedPresenceService", NULL);
+	gchar *url = g_strdup_printf("/v1/pubsub/subscriptions/%s", purple_url_encode(sa->endpoint));
+	guint count = 0;
+
+	while (!g_queue_is_empty(sa->pending_subscription_contacts) && count < 100) {
+		gchar *contact_id = g_queue_pop_head(sa->pending_subscription_contacts);
+
+		JsonObject *contact = json_object_new();
+		gchar *id = g_strconcat(teams_user_url_prefix(contact_id), contact_id, NULL);
+		json_object_set_string_member(contact, "mri", id);
+		json_array_add_object_element(subscriptionsToAdd, contact);
+		g_free(id);
+		g_free(contact_id);
+		count++;
+	}
+
+	JsonObject *obj = json_object_new();
+	json_object_set_string_member(obj, "trouterUri", trouterUri);
+	json_object_set_array_member(obj, "subscriptionsToAdd", subscriptionsToAdd);
+	json_object_set_array_member(obj, "subscriptionsToRemove", subscriptionsToRemove);
+	json_object_set_boolean_member(obj, "shouldPurgePreviousSubscriptions", FALSE);
+	gchar *post = teams_jsonobj_to_string(obj);
+
+	teams_post_or_get(sa, TEAMS_METHOD_POST | TEAMS_METHOD_SSL, TEAMS_PRESENCE_HOST, url, post, NULL, NULL, TRUE);
+
+	g_free(post);
+	json_object_unref(obj);
+	g_free(url);
+	g_free(trouterUri);
+
+	if (g_queue_is_empty(sa->pending_subscription_contacts)) {
+		sa->subscription_flush_timer = 0;
+		return G_SOURCE_REMOVE;
+	}
+
+	return G_SOURCE_CONTINUE;
 }
 
 static gboolean
@@ -1888,24 +2019,17 @@ teams_subscribe_to_contact_status(TeamsAccount *sa, GSList *contacts)
 		return;
 	}
 
-	JsonArray *subscriptionsToAdd = json_array_new();
-	JsonArray *subscriptionsToRemove = json_array_new();
-	gchar *trouterUri = g_strconcat(sa->trouter_surl, "/TeamsUnifiedPresenceService", NULL);
-	gchar *url = g_strdup_printf("/v1/pubsub/subscriptions/%s", purple_url_encode(sa->endpoint));
 	GSList *fallback_contacts = NULL;
-
-	gchar *post;
 	GSList *cur = contacts;
-	guint count = 0;
+
 	do {
-		JsonObject *contact;
-		gchar *id;
+		// Skip contacts we've already subscribed to avoid duplicate subscriptions
+		// and the server-side snapshot storm they cause.
+		if (g_hash_table_lookup(sa->subscribed_contacts, (gconstpointer) cur->data) != NULL) {
+			continue;
+		}
+		g_hash_table_insert(sa->subscribed_contacts, g_strdup(cur->data), GUINT_TO_POINTER(TRUE));
 
-		contact = json_object_new();
-
-		id = g_strconcat(teams_user_url_prefix(cur->data), cur->data, NULL);
-		json_object_set_string_member(contact, "mri", id);
-		json_array_add_object_element(subscriptionsToAdd, contact);
 #ifdef ENABLE_TEAMS_PERSONAL
 		if (g_str_has_prefix(cur->data, "orgid:")) {
 #else
@@ -1914,52 +2038,16 @@ teams_subscribe_to_contact_status(TeamsAccount *sa, GSList *contacts)
 			// Might be an old skype contact that we dont get the realtime presence for
 			fallback_contacts = g_slist_prepend(fallback_contacts, g_strdup(cur->data));
 		}
-		g_free(id);
 
-		if (++count >= 100) {
-			JsonObject *obj = json_object_new();
+		g_queue_push_tail(sa->pending_subscription_contacts, g_strdup(cur->data));
 
-			// Send off the current batch and continue
-			json_object_set_string_member(obj, "trouterUri", trouterUri);
-			json_object_set_array_member(obj, "subscriptionsToAdd", subscriptionsToAdd);
-			json_object_set_array_member(obj, "subscriptionsToRemove", subscriptionsToRemove);
-			json_object_set_boolean_member(obj, "shouldPurgePreviousSubscriptions", FALSE);
-			post = teams_jsonobj_to_string(obj);
+	} while ((cur = g_slist_next(cur)));
 
-			teams_post_or_get(sa, TEAMS_METHOD_POST | TEAMS_METHOD_SSL, TEAMS_PRESENCE_HOST, url, post, NULL, NULL, TRUE);
-
-			g_free(post);
-			json_object_unref(obj);
-
-			subscriptionsToAdd = json_array_new();
-			subscriptionsToRemove = json_array_new();
-			count = 0;
-		}
-	} while((cur = g_slist_next(cur)));
-
-	if (json_array_get_length(subscriptionsToAdd)) {
-		JsonObject *obj = json_object_new();
-
-		// Send off the current batch and continue
-		json_object_set_string_member(obj, "trouterUri", trouterUri);
-		json_object_set_array_member(obj, "subscriptionsToAdd", subscriptionsToAdd);
-		json_object_set_array_member(obj, "subscriptionsToRemove", subscriptionsToRemove);
-		json_object_set_boolean_member(obj, "shouldPurgePreviousSubscriptions", FALSE);
-		post = teams_jsonobj_to_string(obj);
-
-		teams_post_or_get(sa, TEAMS_METHOD_POST | TEAMS_METHOD_SSL, TEAMS_PRESENCE_HOST, url, post, NULL, NULL, TRUE);
-
-		g_free(post);
-		json_object_unref(obj);
-
-	} else {
-		// Would normally be unref'd when obj is unref'd
-		json_array_unref(subscriptionsToAdd);
-		json_array_unref(subscriptionsToRemove);
+	// Start the rate-limited flush timer if it isn't already running.
+	if (sa->subscription_flush_timer == 0 &&
+			!g_queue_is_empty(sa->pending_subscription_contacts)) {
+		sa->subscription_flush_timer = g_timeout_add(50, teams_send_subscription_batch, sa);
 	}
-
-	g_free(url);
-	g_free(trouterUri);
 
 	if (fallback_contacts != NULL) {
 		//TODO we should be polling for the status of these users

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -1529,6 +1529,146 @@ teams_get_conversation_history_since(TeamsAccount *sa, const gchar *convname, gi
 	g_free(url);
 }
 
+#define TEAMS_HISTORY_PAGE_SIZE 30
+#define TEAMS_HISTORY_MAX_PAGES 20
+
+typedef struct {
+	gchar  *convname;
+	gint    since;        /* original earliest timestamp (seconds) */
+	gint    end_before;   /* exclusive upper bound (seconds); 0 = no limit */
+	gint    page_count;   /* safety counter */
+	GSList *all_messages; /* json_object_ref'd JsonObject*, accumulated across pages */
+} TeamsHistoryFetchData;
+
+static gint
+compare_message_composetime(gconstpointer a, gconstpointer b)
+{
+	const gchar *ta = json_object_get_string_member((JsonObject *) a, "composetime");
+	const gchar *tb = json_object_get_string_member((JsonObject *) b, "composetime");
+	time_t tsa = purple_str_to_time(ta, TRUE, NULL, NULL, NULL);
+	time_t tsb = purple_str_to_time(tb, TRUE, NULL, NULL, NULL);
+
+	if (tsa < tsb) return -1;
+	if (tsa > tsb) return  1;
+	return 0;
+}
+
+// Fetch message history using paginated/batched requests to fetch the complete requested time-window
+static void
+teams_got_conv_history_paginated(TeamsAccount *sa, JsonNode *node, gpointer user_data)
+{
+	TeamsHistoryFetchData *fetch = user_data;
+	JsonObject *obj;
+	JsonArray  *messages;
+	gint index, length;
+	gint oldest_ts = 0;
+	gboolean fetch_next = FALSE;
+
+	if (node != NULL && json_node_get_node_type(node) == JSON_NODE_OBJECT) {
+		obj      = json_node_get_object(node);
+		messages = json_object_get_array_member(obj, "messages");
+		length   = json_array_get_length(messages);
+
+		// Accumulate this page's messages (API is newest-first; index 0 = newest).
+		for (index = 0; index < length; index++) {
+			JsonObject  *message          = json_array_get_object_element(messages, index);
+			const gchar *composetime      = json_object_get_string_member(message, "composetime");
+			gint         composetimestamp = (gint) purple_str_to_time(composetime, TRUE, NULL, NULL, NULL);
+
+			// The last element (highest index) is the oldest in a newest-first array.
+			if (index == length - 1)
+				oldest_ts = composetimestamp;
+
+			if (composetimestamp > fetch->since) {
+				json_object_ref(message);
+				fetch->all_messages = g_slist_prepend(fetch->all_messages, message);
+			}
+		}
+
+		 // Request the next (older) page when:
+		 // - we received a full page (more messages likely exist)
+		 // - the oldest message is still within our target window
+		 // - we haven't hit the safety page limit
+		 // - we're making progress (oldest_ts < end_before, so we're not stuck on
+		 //    the same window. If the server ignores endTime it will return the
+		 //    same page and oldest_ts won't be less than the end_before we sent,
+		 //    stopping the loop cleanly)
+		fetch_next = (length == TEAMS_HISTORY_PAGE_SIZE
+				&& oldest_ts > fetch->since
+				&& fetch->page_count < TEAMS_HISTORY_MAX_PAGES
+				&& (fetch->end_before == 0 || oldest_ts < fetch->end_before));
+
+		if (fetch_next) {
+			TeamsHistoryFetchData *next = g_new0(TeamsHistoryFetchData, 1);
+			gchar *url;
+
+			next->convname     = g_strdup(fetch->convname);
+			next->since        = fetch->since;
+			next->end_before   = oldest_ts;
+			next->page_count   = fetch->page_count + 1;
+			next->all_messages = fetch->all_messages; /* transfer ownership */
+			fetch->all_messages = NULL;
+
+			url = g_strdup_printf(
+				TEAMS_CONTACTS_PATH_PREFIX "/v1/users/ME/conversations/%s/messages"
+				"?startTime=%d000&endTime=%d000&pageSize=%d"
+				"&view=msnp24Equivalent&targetType=Passport|Skype|Lync|Thread|PSTN|Agent",
+				purple_url_encode(next->convname),
+				next->since,
+				next->end_before - 1,
+				TEAMS_HISTORY_PAGE_SIZE);
+
+			teams_post_or_get(sa, TEAMS_METHOD_GET | TEAMS_METHOD_SSL,
+					TEAMS_CONTACTS_HOST, url, NULL,
+					teams_got_conv_history_paginated, next, TRUE);
+			g_free(url);
+			g_free(fetch->convname);
+			g_free(fetch);
+			return;
+		}
+	}
+
+	//
+	// All pages received (or an error occurred). Sort the accumulated messages
+	// by composetime ascending (oldest first) so they appear in the correct
+	// order in the chat window, regardless of the order the pages arrived.
+	//
+	fetch->all_messages = g_slist_sort(fetch->all_messages, compare_message_composetime);
+	for (GSList *l = fetch->all_messages; l; l = l->next) {
+		process_message_resource(sa, (JsonObject *) l->data);
+		json_object_unref((JsonObject *) l->data);
+	}
+	g_slist_free(fetch->all_messages);
+
+	g_free(fetch->convname);
+	g_free(fetch);
+}
+
+void
+teams_fetch_conv_history_paginated(TeamsAccount *sa, const gchar *convname, gint since)
+{
+	TeamsHistoryFetchData *fetch = g_new0(TeamsHistoryFetchData, 1);
+	gchar *url;
+
+	fetch->convname   = g_strdup(convname);
+	fetch->since      = since;
+	fetch->end_before = 0;
+	fetch->page_count = 0;
+
+	url = g_strdup_printf(
+		TEAMS_CONTACTS_PATH_PREFIX "/v1/users/ME/conversations/%s/messages"
+		"?startTime=%d000&pageSize=%d"
+		"&view=msnp24Equivalent&targetType=Passport|Skype|Lync|Thread|PSTN|Agent",
+		purple_url_encode(convname),
+		since,
+		TEAMS_HISTORY_PAGE_SIZE);
+
+	teams_post_or_get(sa, TEAMS_METHOD_GET | TEAMS_METHOD_SSL,
+			TEAMS_CONTACTS_HOST, url, NULL,
+			teams_got_conv_history_paginated, fetch, TRUE);
+	g_free(url);
+}
+
 void
 teams_get_conversation_history(TeamsAccount *sa, const gchar *convname)
 {

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -1478,9 +1478,6 @@ teams_got_thread_users(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	}
 	
 	teams_get_friend_profiles(sa, users_to_fetch);
-	if (!is_meeting_chat) {
-		teams_subscribe_to_contact_status(sa, users_to_fetch);
-	}
 	g_slist_free_full(users_to_fetch, g_free);
 }
 
@@ -1709,10 +1706,19 @@ teams_drain_presence_queue(gpointer user_data)
 			continue;
 		}
 
+		// Skip PSTN (telephone) contacts
+		// MRI prefix "4:" means phone number
+		// It is impossible to send or recieve IMs from these contacts, so they
+		// should not be added to the buddy list.
+		if (g_str_has_prefix(mri, "4:")) {
+			json_object_unref(response);
+			continue;
+		}
+
 		const gchar *availability = json_object_get_string_member(presence, "availability");
 		const gchar *from = teams_strip_user_prefix(mri);
 
-		if (!from || !availability) {
+		if (!from || !*from || !availability) {
 			json_object_unref(response);
 			continue;
 		}
@@ -1850,8 +1856,12 @@ teams_got_contact_statuses(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	}
 
 	// Start the drain callback only if it isn't already running.
+	// Use g_timeout_add() instead of g_idle_add() so the drain
+	// makes progress even when the GLib main loop is continuously
+	// occupied with I/O events (a common occurance during login),
+	// which would starve an idle source indefinitely.
 	if (sa->presence_drain_source == 0) {
-		sa->presence_drain_source = g_idle_add(teams_drain_presence_queue, sa);
+		sa->presence_drain_source = g_timeout_add(50, teams_drain_presence_queue, sa);
 	}
 }
 
@@ -2023,6 +2033,13 @@ teams_subscribe_to_contact_status(TeamsAccount *sa, GSList *contacts)
 	GSList *cur = contacts;
 
 	do {
+		// Skip PSTN (telephone) contacts
+		// These start with "+" after the "4:" prefix is stripped. The presence
+		// service has no useful status data for them.
+		if (g_str_has_prefix(cur->data, "+")) {
+			continue;
+		}
+
 		// Skip contacts we've already subscribed to avoid duplicate subscriptions
 		// and the server-side snapshot storm they cause.
 		if (g_hash_table_lookup(sa->subscribed_contacts, (gconstpointer) cur->data) != NULL) {

--- a/teams_messages.c
+++ b/teams_messages.c
@@ -1414,7 +1414,7 @@ teams_got_thread_users(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	gint length, index;
 	PurpleGroup *group = teams_get_blist_group(sa);
 	GSList *users_to_fetch = NULL;
-	gboolean is_meeting_chat = g_str_has_prefix(chatname, "19:meeting_");
+	//gboolean is_meeting_chat = g_str_has_prefix(chatname, "19:meeting_");
 	
 	chatconv = purple_conversations_find_chat_with_account(chatname, sa->account);
 	g_free(chatname);
@@ -1634,7 +1634,8 @@ teams_got_conv_history_paginated(TeamsAccount *sa, JsonNode *node, gpointer user
 	// order in the chat window, regardless of the order the pages arrived.
 	//
 	fetch->all_messages = g_slist_sort(fetch->all_messages, compare_message_composetime);
-	for (GSList *l = fetch->all_messages; l; l = l->next) {
+	GSList *l;
+	for (l = fetch->all_messages; l; l = l->next) {
 		process_message_resource(sa, (JsonObject *) l->data);
 		json_object_unref((JsonObject *) l->data);
 	}
@@ -2036,8 +2037,8 @@ teams_got_contact_statuses(TeamsAccount *sa, JsonNode *node, gpointer user_data)
 	// This caps queue depth at the number of unique contacts rather than at the
 	// number of incoming API responses, preventing unbounded queue growth when
 	// updates arrive faster than the drain can process them.
-	guint len = json_array_get_length(responses);
-	for (guint i = 0; i < len; i++) {
+	guint i, len = json_array_get_length(responses);
+	for (i = 0; i < len; i++) {
 		JsonObject *resp = json_array_get_object_element(responses, i);
 		if (resp == NULL) continue;
 

--- a/teams_messages.h
+++ b/teams_messages.h
@@ -60,6 +60,7 @@ void teams_subscribe_to_contact_status(TeamsAccount *sa, GSList *contacts);
 void teams_subscribe_to_single_contact_status(TeamsAccount *sa, const gchar *username);
 void teams_unsubscribe_from_contact_status(TeamsAccount *sa, const gchar *who);
 void teams_get_conversation_history_since(TeamsAccount *sa, const gchar *convname, gint since);
+void teams_fetch_conv_history_paginated(TeamsAccount *sa, const gchar *convname, gint since);
 void teams_get_conversation_history(TeamsAccount *sa, const gchar *convname);
 void teams_get_thread_users(TeamsAccount *sa, const gchar *convname);
 void teams_get_all_conversations_since(TeamsAccount *sa, gint since);


### PR DESCRIPTION
Contacts and message callbacks were firing hundreds of concurrent presence
subscriptions and profile fetches at login, saturating the GTK main loop
and causing multi-second UI freezes.

- Deduplicate presence subscriptions: skip any contact already present in
  the subscription table before sending, so each contact is subscribed
  exactly once regardless of how many parallel callbacks fire
- Deduplicate profile fetches: skip any contact already present in the
  fetch table before building the POST body
- Process presence snapshots in batches of 20 per idle tick using a
  ref-counted TeamsPresenceBatchData context so the main loop is not
  locked out during the initial snapshot flood
- Process friend profile fetches in batches of 20 per idle tick using
  a ref-counted TeamsBatchProfileData context
- Consolidate all incoming presence data from every API response into a
  single shared drain queue; drain exactly TEAMS_PRESENCE_BATCH_SIZE (20)
  entries per tick, capping buddy-list repaints at 80 per idle tick max
- Replace the burst of self-rescheduling icon-download timers with a
  single recurring timer (teams_process_icon_queue) that respects the
  4-concurrent-download cap and removes itself when the queue empties
- Skip presence subscriptions for meeting chat participants, which have
  no meaningful presence state and were needlessly inflating the
  subscription count

Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic IM conversation history retrieval with configurable lookback and paginated fetch.
  * New account preferences: hide meeting chats, fetch-history toggle, history-days, and calendar notification lead time.

* **Improvements**
  * Safer, deduplicated avatar downloads with stricter validation and shorter timeouts.
  * Batched profile processing, rate‑limited subscription batching and incremental presence processing for smoother performance.
* **Bug Fixes**
  * Meeting chats can be purged/hidden and friend-list parsing hardened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->